### PR TITLE
according to rubocop documentation, .ruby-version is used by default...

### DIFF
--- a/rubocop_all.yml
+++ b/rubocop_all.yml
@@ -1,5 +1,4 @@
 AllCops:
-  TargetRubyVersion: 2.4
   DisplayCopNames: true
   Exclude:
     - '**/templates/**/*'


### PR DESCRIPTION
https://docs.rubocop.org/en/stable/configuration/#setting-the-target-ruby-version